### PR TITLE
Expand attribute matching to all x- attributes

### DIFF
--- a/Syntaxes/HTML (AlpineJS).sublime-syntax
+++ b/Syntaxes/HTML (AlpineJS).sublime-syntax
@@ -8,11 +8,6 @@ version: 2
 
 extends: Packages/HTML/HTML.sublime-syntax
 
-variables:
-  alpinejs_attributes: |-
-    (?x: x-(?: data | init | bind | on | text | html | model | modelable | show
-    | for | transition | effect | ignore | ref | cloak | teleport | if | id ) )
-
 contexts:
 
   tag-attributes:

--- a/Syntaxes/HTML (AlpineJS).sublime-syntax
+++ b/Syntaxes/HTML (AlpineJS).sublime-syntax
@@ -29,7 +29,7 @@ contexts:
         - tag-event-attribute-assignment
         - tag-alpinejs-attribute-name
 
-    - match: '{{alpinejs_attributes}}'
+    - match: 'x-[\w-]+'
       scope: entity.other.attribute-name.alpinejs.html
       push:
         - tag-alpinejs-attribute-meta

--- a/Syntaxes/PHP (AlpineJS).sublime-syntax
+++ b/Syntaxes/PHP (AlpineJS).sublime-syntax
@@ -8,11 +8,6 @@ version: 2
 
 extends: Packages/PHP/PHP.sublime-syntax
 
-variables:
-  alpinejs_attributes: |-
-    (?x: x-(?: data | init | bind | on | text | html | model | modelable | show
-    | for | transition | effect | ignore | ref | cloak | teleport | if | id ) )
-
 contexts:
 
   tag-attributes:
@@ -29,7 +24,7 @@ contexts:
         - tag-event-attribute-assignment
         - tag-alpinejs-attribute-name
 
-    - match: '{{alpinejs_attributes}}'
+    - match: 'x-[\w-]+'
       scope: entity.other.attribute-name.alpinejs.html
       push:
         - tag-alpinejs-attribute-meta


### PR DESCRIPTION
@deathaxe 

Thanks again for the repo. I did some testing and it works really well.
The only change I would propose would be to make the attribute matching more permissive to match all attributes that start with `x-` as there are countless plugins and users might write their own directives.

It is safe to assume that – should a user make use of Alpine.js and thus use this highlighting – that all attributes starting with `x-` are supposed to be alpine.js directives.